### PR TITLE
Linting and updating click behavior of LandingHeader

### DIFF
--- a/client/app/components/LandingHeader/index.js
+++ b/client/app/components/LandingHeader/index.js
@@ -4,12 +4,19 @@ import React from 'react';
 import styles from './styles.scss';
 
 const LandingHeader = () => {
+  // Scroll content area to top of viewport
   // Make an arrow function, free binding of this :D
-  const scrollTo = () => {
+  const scrollToContent = () => {
     const target = document.getElementById('content');
     // scrollIntoView is only supported by Firefox at the moment, remember to
     // import the polyfill for this
     target.scrollIntoView({ block: 'start', behavior: 'smooth' });
+  };
+
+  // Remove focus from button after click to scroll, powered by refs
+  const handleClick = () => {
+    scrollToContent();
+    this.contentArrow.blur();
   };
 
   return (
@@ -19,7 +26,11 @@ const LandingHeader = () => {
           <h1>Hipster Blog Title</h1>
           <h2>Chillwave shabby chic retro glossier seitan pitchfork.</h2>
         </div>
-        <a className={styles.contentArrow} onClick={() => scrollTo()}> </a>
+        <button
+          ref={(button) => { this.contentArrow = button; }}
+          className={styles.contentArrow}
+          onClick={() => handleClick()}
+        />
       </div>
     </header>
   );

--- a/client/app/components/LandingHeader/styles.scss
+++ b/client/app/components/LandingHeader/styles.scss
@@ -67,7 +67,6 @@
 
     -webkit-animation: bounce 4s 2s infinite;
     animation: bounce 4s 2s infinite;
-
   }
 }
 


### PR DESCRIPTION
-Fixing linter issue with <a> not having href by replacing with button.
-This causes the issue of the button being in focus after clicking and scrollIntoView kicking in.
-Fixing through the use of React refs and .blur(), updating onClick of the arrow to handle both the scroll functionality and the focus update.
-No more linter issues with this component :white_check_mark: